### PR TITLE
Fix dark theme for playoff bracket

### DIFF
--- a/src/components/EventPlayoffBracket/PlayoffMatchupAlliance.js
+++ b/src/components/EventPlayoffBracket/PlayoffMatchupAlliance.js
@@ -13,7 +13,10 @@ const useStyles = makeStyles(theme => ({
     display: "flex",
     flexDirection: "column",
     textAlign: "center",
-    backgroundColor: theme.palette.grey[100],
+    backgroundColor:
+      theme.palette.type === "light"
+        ? theme.palette.grey[100]
+        : theme.palette.grey[900],
     borderRadius: theme.spacing(0.5),
     boxShadow: theme.shadows[1],
     overflow: "hidden",


### PR DESCRIPTION
### Before:
![Before screenshot](https://user-images.githubusercontent.com/16443111/72839456-003fcc80-3c9b-11ea-8af7-5441715b3757.png)

### After
![After screenshot](https://user-images.githubusercontent.com/16443111/72839507-10f04280-3c9b-11ea-82dd-ada57f5222e5.png)
